### PR TITLE
Add crowd-cast quickstart page

### DIFF
--- a/public/crowd-cast-quickstart.html
+++ b/public/crowd-cast-quickstart.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>crowd-cast Quickstart | p(doom)</title>
+    <link rel="icon" type="image/png" href="favicon.png">
+    <link rel="stylesheet" href="colors_and_type.css">
+    <link rel="stylesheet" href="marketing.css">
+    <style>
+        .page {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: var(--s-9) var(--s-7) var(--s-10);
+        }
+        .page .section-mark { margin-bottom: var(--s-8); }
+        .page h1 {
+            font-size: var(--fs-h1);
+            margin: 0 0 var(--s-5);
+            max-width: 20ch;
+        }
+        .page-lede {
+            font-family: var(--font-sans);
+            font-size: var(--fs-lede);
+            line-height: 1.6;
+            color: var(--ash-700);
+            max-width: 58ch;
+            margin: 0 0 var(--s-8);
+        }
+
+        /* Download buttons */
+        .dl-row {
+            display: flex;
+            gap: 16px;
+            flex-wrap: wrap;
+            margin-bottom: var(--s-9);
+        }
+        .dl-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 14px 28px;
+            font-family: var(--font-mono);
+            font-size: 13px;
+            font-weight: 500;
+            letter-spacing: .08em;
+            text-transform: uppercase;
+            text-decoration: none;
+            border: 1px solid var(--ash-300);
+            transition: border-color 0.15s, color 0.15s;
+        }
+        .dl-btn--macos {
+            background: var(--ink);
+            color: var(--paper);
+            border-color: var(--ink);
+        }
+        .dl-btn--macos:hover { background: var(--ash-800); border-color: var(--ash-800); }
+        .dl-btn--windows {
+            background: var(--paper);
+            color: var(--ink);
+        }
+        .dl-btn--windows:hover { border-color: var(--ink); }
+        .dl-btn svg { width: 18px; height: 18px; flex-shrink: 0; }
+
+        /* Steps */
+        .qs-section { margin-bottom: var(--s-9); }
+        .qs-section h2 {
+            font-family: var(--font-serif);
+            font-weight: 600;
+            font-size: var(--fs-h3);
+            letter-spacing: -.02em;
+            margin: 0 0 var(--s-6);
+            padding-bottom: var(--s-4);
+            border-bottom: 1px solid var(--ash-300);
+        }
+        .qs-section h3 {
+            font-family: var(--font-sans);
+            font-weight: 600;
+            font-size: var(--fs-h4);
+            margin: var(--s-7) 0 var(--s-4);
+            color: var(--ink);
+        }
+
+        .steps { list-style: none; padding: 0; margin: 0; counter-reset: step; }
+        .steps > li {
+            counter-increment: step;
+            position: relative;
+            padding-left: 48px;
+            margin-bottom: var(--s-6);
+            font-family: var(--font-sans);
+            font-size: 16px;
+            line-height: 1.7;
+            color: var(--ash-700);
+            max-width: 58ch;
+        }
+        .steps > li::before {
+            content: counter(step);
+            position: absolute;
+            left: 0;
+            top: 1px;
+            width: 30px;
+            height: 30px;
+            border-radius: 50%;
+            background: var(--ash-100);
+            border: 1px solid var(--ash-300);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-family: var(--font-mono);
+            font-size: 13px;
+            font-weight: 600;
+            color: var(--ink);
+        }
+        .steps li strong { color: var(--ink); font-weight: 600; }
+
+        /* Callout boxes */
+        .callout {
+            padding: 20px 24px;
+            margin: var(--s-5) 0;
+            font-family: var(--font-sans);
+            font-size: 15px;
+            line-height: 1.65;
+            color: var(--ash-700);
+            max-width: 58ch;
+        }
+        .callout--warn {
+            background: #fef6e4;
+            border-left: 3px solid var(--brass);
+        }
+        .callout--info {
+            background: var(--ash-100);
+            border-left: 3px solid var(--ash-400);
+        }
+        .callout strong { color: var(--ink); }
+        .callout code {
+            font-family: var(--font-mono);
+            font-size: 13px;
+            background: rgba(0,0,0,0.06);
+            padding: 2px 6px;
+            border-radius: 3px;
+        }
+
+        /* Inline code */
+        .page-body code, .steps code {
+            font-family: var(--font-mono);
+            font-size: 13px;
+            background: var(--ash-100);
+            padding: 2px 6px;
+            border-radius: 3px;
+        }
+
+        /* Tray guide */
+        .tray-grid {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 8px 20px;
+            margin: var(--s-5) 0;
+            max-width: 58ch;
+        }
+        .tray-grid dt {
+            font-family: var(--font-sans);
+            font-weight: 600;
+            font-size: 15px;
+            color: var(--ink);
+        }
+        .tray-grid dd {
+            font-family: var(--font-sans);
+            font-size: 15px;
+            color: var(--ash-700);
+            margin: 0;
+        }
+
+        /* Troubleshooting */
+        .ts-item { margin-bottom: var(--s-6); max-width: 58ch; }
+        .ts-item summary {
+            font-family: var(--font-sans);
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--ink);
+            cursor: pointer;
+            padding: var(--s-3) 0;
+        }
+        .ts-item summary:hover { color: var(--ember); }
+        .ts-item p {
+            font-family: var(--font-sans);
+            font-size: 15px;
+            line-height: 1.65;
+            color: var(--ash-700);
+            margin: var(--s-3) 0 0;
+        }
+
+        /* Platform tabs */
+        .platform-tabs {
+            display: flex;
+            gap: 0;
+            margin-bottom: var(--s-7);
+            border-bottom: 1px solid var(--ash-300);
+        }
+        .platform-tab {
+            padding: 12px 24px;
+            font-family: var(--font-mono);
+            font-size: 12px;
+            font-weight: 500;
+            letter-spacing: .12em;
+            text-transform: uppercase;
+            color: var(--ash-500);
+            cursor: pointer;
+            border: none;
+            background: none;
+            border-bottom: 2px solid transparent;
+            margin-bottom: -1px;
+            transition: color 0.15s;
+        }
+        .platform-tab:hover { color: var(--ink); }
+        .platform-tab.active {
+            color: var(--ink);
+            border-bottom-color: var(--ember);
+        }
+        .platform-content { display: none; }
+        .platform-content.active { display: block; }
+
+        @media (max-width: 960px) {
+            .page { padding: var(--s-8) var(--s-6) var(--s-9); }
+            .page h1 { font-size: 44px; }
+        }
+        @media (max-width: 600px) {
+            .page { padding: var(--s-7) var(--s-5) var(--s-8); }
+            .page h1 { font-size: 36px; }
+            .dl-row { flex-direction: column; }
+            .dl-btn { justify-content: center; }
+            .steps li { padding-left: 40px; }
+        }
+    </style>
+</head>
+<body>
+    <header class="site-header" data-surface="void">
+        <div class="container">
+            <nav class="nav">
+                <a class="brand" href="/">
+                    <img class="sigil-img" src="logo-mark-inverted.png" alt="">
+                    <span class="wm">p(doom)</span>
+                </a>
+                <div class="nav-links">
+                    <a href="/blog.html">Research</a>
+                    <a href="/about.html">About</a>
+                    <a href="/supply.html">Supply</a>
+                    <a href="https://discord.gg/G4JNuPX2VR">Join</a>
+                </div>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <article class="page">
+            <header class="section-mark">
+                <span class="eyebrow">§ crowd-cast</span>
+            </header>
+            <h1>Quickstart</h1>
+            <p class="page-lede">Get crowd-cast running in under five minutes. Install, grant permissions, and you're recording.</p>
+
+            <!-- Download buttons -->
+            <div class="dl-row">
+                <a class="dl-btn dl-btn--macos" href="https://github.com/p-doom/crowd-cast/releases/latest/download/CrowdCast.dmg">
+                    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
+                    Download for macOS
+                </a>
+                <a class="dl-btn dl-btn--windows" href="https://github.com/p-doom/crowd-cast/releases/latest/download/crowd-cast-setup.exe">
+                    <svg viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-1.501L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-13.051-1.801z"/></svg>
+                    Download for Windows
+                </a>
+            </div>
+
+            <!-- Platform tabs -->
+            <div class="platform-tabs">
+                <button class="platform-tab active" onclick="switchPlatform('macos')">macOS</button>
+                <button class="platform-tab" onclick="switchPlatform('windows')">Windows</button>
+            </div>
+
+            <!-- ==================== macOS ==================== -->
+            <div id="platform-macos" class="platform-content active">
+                <section class="qs-section">
+                    <h2>Install</h2>
+                    <ol class="steps">
+                        <li>Open <strong><a href="https://github.com/p-doom/crowd-cast/releases/latest/download/CrowdCast.dmg" style="color:var(--ember);">CrowdCast.dmg</a></strong> and drag the app to your Applications folder.</li>
+                        <li>Launch <strong>CrowdCast</strong> from Applications. The setup wizard opens automatically on first run.</li>
+                        <li>The wizard asks for two macOS permissions. Grant both:
+                            <ol type="a" style="margin-top:8px; padding-left:20px; color:var(--ash-700);">
+                                <li><strong>Screen Recording</strong> (required to capture windows)</li>
+                                <li><strong>Accessibility</strong> (required for keyboard and mouse input)</li>
+                            </ol>
+                        </li>
+                        <li>Configure your preferences in the wizard:
+                            <ol type="a" style="margin-top:8px; padding-left:20px; color:var(--ash-700);">
+                                <li><strong>Select the apps you want to record</strong> (e.g. your browser, terminal, IDE). Only selected apps are captured. Everything else is ignored.</li>
+                                <li><strong>Enable "Start at login"</strong> so crowd-cast runs automatically whenever you log in. We recommend keeping this on.</li>
+                            </ol>
+                        </li>
+                        <li><strong>Sign in with Google</strong> when prompted. This links your recordings to your account on the <a href="https://pdoom.org/crowd_cast_dashboard.html" style="color:var(--ember);">dashboard</a> so we can track your contributions.</li>
+                        <li>Click <strong>Done</strong>. The app restarts and appears as a small icon in your menu bar. Recording starts automatically.</li>
+                    </ol>
+
+                </section>
+            </div>
+
+            <!-- ==================== Windows ==================== -->
+            <div id="platform-windows" class="platform-content">
+                <section class="qs-section">
+                    <h2>Install</h2>
+                    <ol class="steps">
+                        <li>Run <strong><a href="https://github.com/p-doom/crowd-cast/releases/latest/download/crowd-cast-setup.exe" style="color:var(--ember);">crowd-cast-setup.exe</a></strong>. The installer places the app under your user profile (no admin or UAC prompt required).</li>
+                        <li>
+                            <strong>SmartScreen warning:</strong> Because the app is not yet widely distributed, Windows may show <em>"Windows protected your PC"</em>. Click <strong>More info</strong>, then <strong>Run anyway</strong>.
+                        </li>
+                        <li>Configure your preferences in the setup wizard:
+                            <ol type="a" style="margin-top:8px; padding-left:20px; color:var(--ash-700);">
+                                <li><strong>Select the apps you want to record</strong>. Only selected apps are captured. Everything else is ignored.</li>
+                                <li><strong>Enable "Start at login"</strong> so crowd-cast runs automatically whenever you log in. We recommend keeping this on.</li>
+                            </ol>
+                        </li>
+                        <li><strong>Sign in with Google</strong> when prompted. This links your recordings to your account on the <a href="https://pdoom.org/crowd_cast_dashboard.html" style="color:var(--ember);">dashboard</a> so we can track your contributions.</li>
+                        <li>On first launch, crowd-cast <strong>downloads OBS components</strong> automatically (one-time, needs internet). The app relaunches itself when done. This takes about 30 to 60 seconds.
+                            <div class="callout callout--warn">
+                                <strong>Don't close the app</strong> during the initial OBS download. If interrupted, delete the install folder and re-run the installer.
+                            </div>
+                        </li>
+                        <li>After the relaunch, crowd-cast appears in your <strong>system tray</strong> (bottom-right, near the clock). Recording starts automatically.</li>
+                    </ol>
+                </section>
+            </div>
+
+            <!-- ==================== Common sections ==================== -->
+            <div class="callout callout--info" style="max-width:58ch; margin-bottom:var(--s-9);">
+                <strong>How we use it:</strong> We record one browser (e.g. Firefox) for research, a text editor (e.g. Cursor), a terminal (e.g. Ghostty), and a PDF viewer (e.g. Preview). We use a <em>separate</em> browser (e.g. Chrome) for sensitive things like email, messaging, and contracts. That browser is simply not in the list, so it never gets recorded. When you switch to an app that isn't selected, crowd-cast captures a black screen and stops logging input. The more apps you record, the more useful the data, so add anything you're comfortable sharing. We found this setup covers the majority of the working day while keeping anything private completely out of the recording.
+            </div>
+
+            <section class="qs-section">
+                <h2>Using crowd-cast</h2>
+                <p style="font-family:var(--font-sans); font-size:16px; line-height:1.7; color:var(--ash-700); max-width:58ch; margin:0 0 var(--s-5);">
+                    Everything is controlled from the tray icon in your menu bar (macOS) or system tray (Windows).
+                </p>
+
+                <dl class="tray-grid">
+                    <dt>Start / Stop Recording</dt>
+                    <dd>Click the tray icon and choose Start or Stop. A green dot means recording is active.</dd>
+
+                    <dt>Delete last 10 minutes</dt>
+                    <dd>The panic button. Deletes recent recordings that haven't been uploaded yet.</dd>
+
+                    <dt>Pause / Resume Uploads</dt>
+                    <dd>Temporarily holds completed segments on disk instead of uploading them.</dd>
+
+                    <dt>Settings</dt>
+                    <dd>Change which apps are recorded. Takes effect on the next segment.</dd>
+
+                    <dt>Sign in with Google</dt>
+                    <dd>Please sign in so your recordings appear on the <a href="https://pdoom.org/crowd_cast_dashboard.html" style="color:var(--ember);">dashboard</a>. Without signing in, your contributions can't be attributed to you.</dd>
+                </dl>
+
+                <div class="callout callout--info">
+                    <strong>Idle detection:</strong> crowd-cast automatically pauses when you step away (no keyboard or mouse activity for 2 minutes) and resumes when you return. No data is recorded while you're idle.
+                </div>
+            </section>
+
+            <section class="qs-section">
+                <h2>Learn more</h2>
+                <p style="font-family:var(--font-sans); font-size:16px; line-height:1.7; color:var(--ash-700); max-width:58ch; margin:0 0 var(--s-5);">
+                    <a href="https://pdoom.org/crowd_cast.html" style="color:var(--ember);">crowd-cast: Crowd-Sourcing Months-Long Trajectories of Human Computer Work</a><br>
+                    <span style="font-size:14px; color:var(--ash-600);">The research behind the project and how the data is used.</span>
+                </p>
+                <p style="font-family:var(--font-sans); font-size:16px; line-height:1.7; color:var(--ash-700); max-width:58ch; margin:0 0 var(--s-5);">
+                    <a href="https://pdoom.org/crowd_cast_dashboard.html" style="color:var(--ember);">Dashboard</a><br>
+                    <span style="font-size:14px; color:var(--ash-600);">See your contributions and overall collection progress.</span>
+                </p>
+            </section>
+
+            <section class="qs-section">
+                <h2>Troubleshooting</h2>
+
+                <details class="ts-item">
+                    <summary>Recording shows "no capture sources"</summary>
+                    <p><strong>macOS:</strong> Screen Recording permission was denied or revoked. Open <strong>System Settings &rarr; Privacy &amp; Security &rarr; Screen Recording</strong>, find CrowdCast, and toggle it on. You may need to quit and relaunch the app.</p>
+                    <p><strong>Windows:</strong> No special permissions are needed. If you see this, the OBS download may have failed. Check your internet connection, delete the install folder at <code>%LOCALAPPDATA%\Programs\crowd-cast</code>, and re-run the installer.</p>
+                </details>
+
+                <details class="ts-item">
+                    <summary>The tray icon doesn't appear</summary>
+                    <p><strong>macOS:</strong> Check if the app is running in Activity Monitor. If it is, the icon may be hidden. Look for the overflow area (arrow) on the right side of the menu bar.</p>
+                    <p><strong>Windows:</strong> Click the <strong>^</strong> arrow in the system tray to see hidden icons. You can drag crowd-cast to the always-visible area.</p>
+                </details>
+
+                <details class="ts-item">
+                    <summary>Uploads are failing</summary>
+                    <p>Segments are retried automatically with exponential backoff (30 seconds up to 2 hours). Check your internet connection. If uploads are paused, resume them from the tray menu. Segments are stored locally until they upload successfully.</p>
+                </details>
+
+                <details class="ts-item">
+                    <summary>I want to re-run the setup wizard</summary>
+                    <p><strong>macOS:</strong> Quit crowd-cast, then run from Terminal:<br><code>/Applications/CrowdCast.app/Contents/MacOS/crowd-cast-agent --setup</code></p>
+                    <p><strong>Windows:</strong> Quit crowd-cast from the tray, then run from Command Prompt or PowerShell:<br><code>"%LOCALAPPDATA%\Programs\crowd-cast\crowd-cast-agent.exe" --setup</code></p>
+                </details>
+
+                <details class="ts-item">
+                    <summary>I signed in but can't see my recordings on the dashboard</summary>
+                    <p>The <a href="https://pdoom.org/crowd_cast_dashboard.html" style="color:var(--ember);">dashboard</a> updates roughly once per hour, so new recordings won't appear immediately. If your data still doesn't show up after an hour, try signing out and back in from the tray menu. If that doesn't help either, reach out to us.</p>
+                </details>
+
+                <details class="ts-item">
+                    <summary>Where are the logs?</summary>
+                    <p><strong>macOS:</strong> <code>~/Library/Logs/crowd-cast/</code></p>
+                    <p><strong>Windows:</strong> <code>%LOCALAPPDATA%\crowd-cast\logs\</code></p>
+                    <p>Share these with us on <a href="https://discord.gg/G4JNuPX2VR" style="color:var(--ember);">Discord</a> if you need help debugging.</p>
+                </details>
+
+                <details class="ts-item">
+                    <summary>How do I uninstall?</summary>
+                    <p><strong>macOS:</strong> Quit the app, then drag CrowdCast from Applications to the Trash. To also remove configuration and logs: delete <code>~/Library/Application Support/dev.crowd-cast.agent/</code> and <code>~/Library/Logs/crowd-cast/</code>.</p>
+                    <p><strong>Windows:</strong> Open <strong>Settings &rarr; Apps &rarr; Installed apps</strong>, find crowd-cast, and click Uninstall. The uninstaller stops the agent, removes the autostart entry, and deletes the install directory.</p>
+                </details>
+
+                <p style="font-family:var(--font-sans); font-size:15px; line-height:1.65; color:var(--ash-600); max-width:58ch; margin-top:var(--s-7);">
+                    Running into something not listed here? <a href="https://github.com/p-doom/crowd-cast/issues" style="color:var(--ember);">Open an issue</a> or email <a href="mailto:mihir@pdoom.org" style="color:var(--ember);">mihir@pdoom.org</a>.
+                </p>
+            </section>
+
+        </article>
+    </main>
+
+    <footer class="site-footer" data-surface="void">
+        <div class="container">
+            <div class="footer-row">
+                <a class="brand" href="/">
+                    <img class="sigil-img" src="logo-mark-inverted.png" alt="">
+                    <span class="wm">p(doom)</span>
+                </a>
+                <nav class="footer-links">
+                    <a href="https://github.com/p-doom/">GitHub</a>
+                    <a href="https://discord.gg/G4JNuPX2VR">Discord</a>
+                    <a href="https://x.com/@prob_doom">Twitter</a>
+                    <a href="https://www.linkedin.com/company/p-doom">LinkedIn</a>
+                    <a href="https://huggingface.co/p-doom">HuggingFace</a>
+                    <a href="/imprint.html">Imprint</a>
+                </nav>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        function switchPlatform(platform) {
+            document.querySelectorAll('.platform-tab').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('.platform-content').forEach(c => c.classList.remove('active'));
+            document.getElementById('platform-' + platform).classList.add('active');
+            document.querySelector('[onclick="switchPlatform(\'' + platform + '\')"]').classList.add('active');
+        }
+
+        // Auto-detect platform
+        (function() {
+            var ua = navigator.userAgent || navigator.platform || '';
+            if (/Win/.test(ua)) switchPlatform('windows');
+        })();
+    </script>
+</body>
+</html>

--- a/public/crowd_cast.html
+++ b/public/crowd_cast.html
@@ -86,7 +86,7 @@
   </d-front-matter>
   <d-title>
     <p>
-    We introduce <a href="https://github.com/p-doom/crowd-cast">crowd-cast</a>, a privacy-preserving desktop application that allows anyone to participate in crowd-sourcing an action-annotated long-horizon behaviour-cloning dataset of computer work. <a href="https://github.com/p-doom/crowd-cast/releases">Install</a> once, and forget about it.
+    We introduce <a href="https://github.com/p-doom/crowd-cast">crowd-cast</a>, a privacy-preserving desktop application that allows anyone to participate in crowd-sourcing an action-annotated long-horizon behaviour-cloning dataset of computer work. <a href="/crowd-cast-quickstart.html">Install</a> once, and forget about it.
     </p>
   </d-title>
   <d-byline></d-byline>
@@ -96,9 +96,7 @@
       <strong>We are now paying people to install crowd-cast:</strong> <a href="https://x.com/prob_doom/status/2056306074722996482" target="_blank">read the announcement</a>
     </p>
     <p style="border-top: 1px solid rgba(0, 0, 0, 0.1); border-bottom: 1px solid rgba(0, 0, 0, 0.1); padding: 1rem 0; margin: 0 0; grid-column: page; text-align: center; font-size: 1.1em;">
-      <strong>Install crowd-cast on <a href="https://github.com/p-doom/crowd-cast/releases" target="_blank" style="color: #0000ee;">macOS</a></strong>
-      <br>
-      (Windows and Linux support are coming soon)
+      <strong><a href="/crowd-cast-quickstart.html">Install crowd-cast</a></strong>
     </p>
     <figure style="grid-column: page; margin: 1rem 0; display: flex; gap: 1rem; flex-wrap: wrap; justify-content: center"><video src="crowd-cast-2.mp4"
     style="width: 100%; min-width: 280px; border-radius: 8px; border: 1px solid var(--ink); box-sizing: border-box;" controls autoplay loop muted></video>

--- a/public/crowd_cast.html
+++ b/public/crowd_cast.html
@@ -96,7 +96,7 @@
       <strong>We are now paying people to install crowd-cast:</strong> <a href="https://x.com/prob_doom/status/2056306074722996482" target="_blank">read the announcement</a>
     </p>
     <p style="border-top: 1px solid rgba(0, 0, 0, 0.1); border-bottom: 1px solid rgba(0, 0, 0, 0.1); padding: 1rem 0; margin: 0 0; grid-column: page; text-align: center; font-size: 1.1em;">
-      <strong><a href="/crowd-cast-quickstart.html">Install crowd-cast</a></strong>
+      <strong><a href="/crowd-cast-quickstart.html">Install crowd-cast</a> and start recording today.</strong>
     </p>
     <figure style="grid-column: page; margin: 1rem 0; display: flex; gap: 1rem; flex-wrap: wrap; justify-content: center"><video src="crowd-cast-2.mp4"
     style="width: 100%; min-width: 280px; border-radius: 8px; border: 1px solid var(--ink); box-sizing: border-box;" controls autoplay loop muted></video>

--- a/public/crowd_cast.html
+++ b/public/crowd_cast.html
@@ -93,10 +93,8 @@
   <d-article>
     <aside><sup>*</sup>Equal contribution</aside>
     <p style="border-top: 1px solid rgba(0, 0, 0, 0.1); border-bottom: 1px solid rgba(0, 0, 0, 0.1); padding: 1rem 0; margin: 1.5rem 0; grid-column: page; text-align: center; font-size: 1.1em;">
-      <strong>We are now paying people to install crowd-cast:</strong> <a href="https://x.com/prob_doom/status/2056306074722996482" target="_blank">read the announcement</a>
-    </p>
-    <p style="border-top: 1px solid rgba(0, 0, 0, 0.1); border-bottom: 1px solid rgba(0, 0, 0, 0.1); padding: 1rem 0; margin: 0 0; grid-column: page; text-align: center; font-size: 1.1em;">
-      <strong><a href="/crowd-cast-quickstart.html">Install crowd-cast</a> and start recording today.</strong>
+      <strong><a href="/crowd-cast-quickstart.html">Install crowd-cast</a> and start recording today.</strong><br>
+      We are now paying people to participate in the data collection: <a href="https://x.com/prob_doom/status/2056306074722996482" target="_blank">read the announcement</a>.
     </p>
     <figure style="grid-column: page; margin: 1rem 0; display: flex; gap: 1rem; flex-wrap: wrap; justify-content: center"><video src="crowd-cast-2.mp4"
     style="width: 100%; min-width: 280px; border-radius: 8px; border: 1px solid var(--ink); box-sizing: border-box;" controls autoplay loop muted></video>


### PR DESCRIPTION
## Summary
- New standalone quickstart page at `/crowd-cast-quickstart.html`
- Platform tabs (macOS/Windows) with auto-detection
- Step-by-step install instructions including permissions, sign-in, start-at-login
- "How we use it" privacy guidance (two-browser pattern)
- Tray usage reference, troubleshooting FAQ, learn more links
- Updates `crowd_cast.html` install links to point to the quickstart

## Test plan
- [ ] Verify page renders correctly at `pdoom.org/crowd-cast-quickstart.html`
- [ ] Check platform auto-detection (macOS tab default on Mac, Windows on Windows)
- [ ] Verify all download links resolve to GitHub Releases assets
- [ ] Verify dashboard and research page links work
- [ ] Check mobile responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)