### PR TITLE
Dashboard: retry SCA-held payouts + payment error display

### DIFF
--- a/public/crowd_cast_dashboard.html
+++ b/public/crowd_cast_dashboard.html
@@ -2499,7 +2499,9 @@
             var p = _payoutsData[i];
             var part = _payoutsParticipants[p.participant_id] || {};
             var isPending = p.status === 'pending';
-            if (isPending) { pendingCount++; pendingTotal += p.amount_usd; }
+            var isScaRetry = p.status === 'approved' && p.requires_sca;
+            var canApprove = isPending || isScaRetry;
+            if (canApprove) { pendingCount++; pendingTotal += p.amount_usd; }
 
             var dueDate = p.period_end ? new Date(p.period_end + 'T23:59:59') : null;
             var isDueSoon = isPending && dueDate && (dueDate.getTime() - now.getTime()) <= sevenDaysMs;
@@ -2511,7 +2513,7 @@
 
             html += '<tr style="background:' + rowBg + ';">';
             html += '<td style="padding:7px 12px;border-bottom:1px solid #eee;">';
-            if (isPending) html += '<input type="checkbox" class="payout-checkbox" data-id="' + escapeHtml(p.payout_id) + '">';
+            if (canApprove) html += '<input type="checkbox" class="payout-checkbox" data-id="' + escapeHtml(p.payout_id) + '">';
             html += '</td>';
             html += '<td style="padding:7px 12px;font-size:13px;font-family:\'SF Mono\',monospace;border-bottom:1px solid #eee;">' + escapeHtml(part.name || p.participant_id) + '</td>';
             html += '<td style="padding:7px 12px;font-size:12px;font-family:\'SF Mono\',monospace;color:#777;border-bottom:1px solid #eee;">' + escapeHtml(p.period_start) + ' to ' + escapeHtml(p.period_end) + '</td>';
@@ -2522,7 +2524,9 @@
             html += '<span style="color:' + statusColor + ';font-weight:700;text-transform:uppercase;">' + escapeHtml(p.status) + '</span>';
             if (isOverdue) html += ' <span style="background:#cf222e;color:#fff;font-size:9px;font-weight:700;padding:2px 5px;letter-spacing:0.5px;">OVERDUE</span>';
             else if (isDueSoon) html += ' <span style="background:#b08800;color:#fff;font-size:9px;font-weight:700;padding:2px 5px;letter-spacing:0.5px;">DUE SOON</span>';
+            if (isScaRetry) html += ' <span style="background:#b08800;color:#fff;font-size:9px;font-weight:700;padding:2px 5px;letter-spacing:0.5px;">AWAITING SCA</span>';
             if (p.approved_by) html += '<br><span style="color:#999;font-size:10px;">by ' + escapeHtml(p.approved_by) + '</span>';
+            if (p.payment_error && p.status !== 'paid') html += '<br><span style="color:#cf222e;font-size:10px;font-weight:400;text-transform:none;">' + escapeHtml(p.payment_error) + '</span>';
             html += '</td>';
             html += '</tr>';
         }


### PR DESCRIPTION
- Payouts in status `approved` with `requires_sca` are selectable again, so a payment awaiting phone approval can be completed with a second click.
- New AWAITING SCA badge and inline `payment_error` text in the status column.
- Pairs with the lambda-side Qonto OAuth2 + VOP + SCA flow (deployed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)