### PR TITLE
Remove cosmetic currency dropdown from onboarding form

### DIFF
--- a/public/onboard.html
+++ b/public/onboard.html
@@ -445,37 +445,7 @@
                     <input class="field-input" type="text" id="f-bank" placeholder="Commerzbank, Germany">
                 </div>
                 <div class="field">
-                    <label class="field-label">Currency preference</label>
-                    <select class="field-select" id="f-currency">
-                        <option value="EUR">EUR (Euro)</option>
-                        <option value="GBP">GBP (British Pound)</option>
-                        <option value="CHF">CHF (Swiss Franc)</option>
-                        <option value="USD">USD (US Dollar)</option>
-                        <option value="SEK">SEK (Swedish Krona)</option>
-                        <option value="DKK">DKK (Danish Krone)</option>
-                        <option value="NOK">NOK (Norwegian Krone)</option>
-                        <option value="CZK">CZK (Czech Koruna)</option>
-                        <option value="HUF">HUF (Hungarian Forint)</option>
-                        <option value="RON">RON (Romanian Leu)</option>
-                        <option value="INR">INR (Indian Rupee)</option>
-                        <option value="CAD">CAD (Canadian Dollar)</option>
-                        <option value="AUD">AUD (Australian Dollar)</option>
-                        <option value="JPY">JPY (Japanese Yen)</option>
-                        <option value="CNY">CNY (Chinese Yuan)</option>
-                        <option value="HKD">HKD (Hong Kong Dollar)</option>
-                        <option value="SGD">SGD (Singapore Dollar)</option>
-                        <option value="ILS">ILS (Israeli Shekel)</option>
-                        <option value="TRY">TRY (Turkish Lira)</option>
-                        <option value="THB">THB (Thai Baht)</option>
-                        <option value="AED">AED (UAE Dirham)</option>
-                        <option value="ZAR">ZAR (South African Rand)</option>
-                        <option value="MXN">MXN (Mexican Peso)</option>
-                        <option value="MAD">MAD (Moroccan Dirham)</option>
-                        <option value="VND">VND (Vietnamese Dong)</option>
-                        <option value="CLP">CLP (Chilean Peso)</option>
-                        <option value="CRC">CRC (Costa Rican Colon)</option>
-                        <option value="UYU">UYU (Uruguayan Peso)</option>
-                    </select>
+                    <div class="field-hint">Payouts are denominated in USD and paid to your account in its local currency (EUR for European accounts) at the official ECB exchange rate. Each payment statement shows the exact conversion.</div>
                 </div>
 
                 <div class="btn-row">
@@ -951,7 +921,6 @@
             holder: document.getElementById('f-holder').value.trim(),
             iban: clean('f-iban').toUpperCase(),
             bank: document.getElementById('f-bank').value.trim(),
-            currency: document.getElementById('f-currency').value,
         };
         if (mode === 'us') {
             pd.routing_number = clean('f-routing');


### PR DESCRIPTION
## What

Removes the "Currency preference" dropdown (`f-currency`) from the payout step of `public/onboard.html` and replaces it with a short informational note (styled with the existing `field-hint` class):

> Payouts are denominated in USD and paid to your account in its local currency (EUR for European accounts) at the official ECB exchange rate. Each payment statement shows the exact conversion.

Also removes the `currency:` line from the `buildPayoutDetails()` payload so no JS references the removed element.

## Why

The dropdown stored a value the payment system completely ignores. Payouts are denominated in USD and the payout rail is determined by the participant's bank account (SEPA in EUR for IBAN accounts at the ECB rate, local currency on international rails). The field only created confusion: a participant believed he had chosen to be paid in dollars.

No backend changes needed: the lambda already defaults the stored currency to "EUR" when the field is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)