### PR TITLE
Participate page: hero apply button + sharpened copy

### DIFF
--- a/public/marketing.css
+++ b/public/marketing.css
@@ -776,6 +776,27 @@ h1.hero-manifesto.display {
 }
 .btn-apply:hover { background: var(--ember); border-color: var(--ember); color: var(--paper); }
 
+/* Hero-sized apply button: the first thing visitors should see. */
+.btn-apply--hero {
+  font-size: 18px;
+  letter-spacing: .12em;
+  padding: 22px 48px;
+  margin: 8px 0 4px;
+}
+.apply-hero {
+  margin: 28px 0 12px;
+}
+.apply-hero .apply-note {
+  display: block;
+  margin-top: 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-60, #666);
+}
+@media (max-width: 640px) {
+  .btn-apply--hero { display: flex; justify-content: center; width: 100%; }
+}
+
 /* ===== Inline form (crowd-cast signup) ======================== */
 .signup-form {
   margin-top: var(--s-7);

--- a/public/open_calls/04_crowd_cast.html
+++ b/public/open_calls/04_crowd_cast.html
@@ -51,9 +51,9 @@
             </div>
 
             <div class="page-prose page-prose--wide">
-                <p>We are p(doom), an AGI research lab in Munich. Our goal is models that can perform complex work over weeks and months, and that takes training data nobody has: recordings of real, long-horizon work. <a href="/docs/crowd-cast/">crowd-cast</a> is our open-source desktop recorder built for exactly that. Over <strong>3,000 hours</strong> recorded so far by the team and early participants, watch it grow on the <a href="/crowd_cast_dashboard.html">live dashboard</a>.</p>
-                <p>We pay accepted participants <strong>$300 per month</strong> to record their normal screen work: research, engineering, coding, CAD and hardware workflows, thesis or PhD projects, serious side projects. We especially want the work current AI <em>can't</em> do yet. It has to be work you have the right to share, your own projects and research, not your employer's confidential material.</p>
-                <p>You keep working exactly as before. No tasks, no deadlines, no meetings: you are selling recordings of work you were doing anyway, not your labor.</p>
+                <p>We are p(doom), an AGI research lab in Munich. Our goal is models that can perform complex work over weeks and months, and that takes training data nobody has: recordings of real, long-horizon work. <a href="/docs/crowd-cast/">crowd-cast</a> is our open-source desktop recorder, built to capture the largest open dataset of long-horizon computer work. Over <strong>3,000 hours</strong> recorded so far by the team and early participants, watch it grow on the <a href="/crowd_cast_dashboard.html">live dashboard</a>.</p>
+                <p>We pay accepted participants <strong>$300 per month</strong> to record their normal screen work: research, engineering, coding, CAD and hardware workflows. That can be your bachelor or master thesis, a semester project, PhD research, a research job, or a serious side project. We especially want the work current AI <em>can't</em> do yet. It has to be work you have the right to share, your own projects and research, not your employer's confidential material.</p>
+                <p>You keep working exactly as before. No tasks, no deadlines, no meetings: you are selling recordings of work you were doing anyway, not your labor. Install once and forget about it.</p>
             </div>
 
             <section class="detail-section">

--- a/public/open_calls/04_crowd_cast.html
+++ b/public/open_calls/04_crowd_cast.html
@@ -54,7 +54,7 @@
                 <p>We are p(doom), an AGI research lab. Our goal is to enable models to perform complex tasks over weeks and months. To elicit such capabilities, we need to train on such data.</p>
                 <p>A few weeks ago we launched <a href="/docs/crowd-cast/">crowd-cast</a>, a privacy-preserving desktop application to capture the largest open long-horizon dataset of digital work. Since then, we have already captured over 3000 hours of work sessions by members of the p(doom) team and early participants (<a href="/crowd_cast_dashboard.html">live dashboard</a>).</p>
                 <p>We are now expanding our data collection efforts to the public and compensate participants <strong>$300 per month</strong> simply for passively recording their work.</p>
-                <p>If you work on open-source projects, and your work involves research, engineering, design, editing, or other long-horizon work, consider participating! This can be a bachelor/master thesis, semester projects, PhD research, a research job at a lab, or even side projects. Simply fill out the form and we will reach out to you.</p>
+                <p>If your work involves research, engineering, design, editing, or other long-horizon work, consider participating! This can be a bachelor/master thesis, semester projects, PhD research, a research job at a lab, or even side projects. Simply fill out the form and we will reach out to you.</p>
             </div>
 
             <section class="detail-section">
@@ -74,7 +74,7 @@
                     <span class="eyebrow">Privacy &amp; trust</span>
                 </header>
                 <div class="page-prose page-prose--wide">
-                    <p>Our privacy-preserving tool lets you choose exactly which applications you want to capture. Private applications, pop-ups and notifications are not captured, and the recording can be started and stopped at any time through the UI. Install once and forget about it! Deletion requests are honored, including derived data.</p>
+                    <p>Our privacy-preserving tool lets you choose exactly which applications you want to capture. Private applications, pop-ups and notifications are not captured, and the recording can be started and stopped at any time through the UI. Install once and forget about it! Record only work you have the right to share, confidential employer or client material doesn't qualify. Deletion requests are honored, including derived data.</p>
                     <p>Nothing here is take-our-word-for-it: the recorder is <a href="https://github.com/p-doom/crowd-cast">open source</a>, and the exact agreements you'd accept are public before you apply: the <a href="/docs/crowd-cast-data-purchase-agreement.pdf">Data Purchase Agreement</a> and the <a href="/docs/crowd-cast-privacy-consent.pdf">Privacy &amp; Recording Consent</a> (GDPR). p(doom) is publicly funded by <a href="https://www.sprind.org">SPRIND</a>, the German Federal Agency for Breakthrough Innovation.</p>
                 </div>
             </section>

--- a/public/open_calls/04_crowd_cast.html
+++ b/public/open_calls/04_crowd_cast.html
@@ -45,10 +45,15 @@
             <h1>Get paid to record your work.</h1>
             <p class="detail-tag"><span class="dot">●</span>live · remote · $300 per month</p>
 
+            <div class="apply-hero">
+                <a class="btn-apply btn-apply--hero" href="https://docs.google.com/forms/d/e/1FAIpQLSd50ZarNRKoIWDmy5xAn8K8FVGM2Jbk1T52er4YLHiP2P28rQ/viewform" target="_blank" rel="noopener">Apply now <span aria-hidden>→</span></a>
+                <span class="apply-note">2-minute application · $75 after the trial week · quit anytime</span>
+            </div>
+
             <div class="page-prose page-prose--wide">
-                <p><a href="/docs/crowd-cast/">crowd-cast</a> is our desktop app for recording long-horizon computer-use data. The <a href="/crowd_cast_dashboard.html">live dashboard</a> shows current collection progress.</p>
-                <p>We pay accepted participants <strong>$300 per month</strong> to record open-source work. Eligible work includes research, engineering, design, editing, and other long-horizon computer tasks.</p>
-                <p>To participate, apply through the <a href="https://docs.google.com/forms/d/e/1FAIpQLSd50ZarNRKoIWDmy5xAn8K8FVGM2Jbk1T52er4YLHiP2P28rQ/viewform" target="_blank" rel="noopener">signup form</a>. If accepted, you install crowd-cast, choose which applications can be recorded, and keep working as usual.</p>
+                <p>We are p(doom), an AGI research lab in Munich. Our goal is models that can perform complex work over weeks and months, and that takes training data nobody has: recordings of real, long-horizon work. <a href="/docs/crowd-cast/">crowd-cast</a> is our open-source desktop recorder built for exactly that. Over <strong>3,000 hours</strong> recorded so far by the team and early participants, watch it grow on the <a href="/crowd_cast_dashboard.html">live dashboard</a>.</p>
+                <p>We pay accepted participants <strong>$300 per month</strong> to record their normal screen work: research, engineering, coding, CAD and hardware workflows, thesis or PhD projects, serious side projects. We especially want the work current AI <em>can't</em> do yet. It has to be work you have the right to share, your own projects and research, not your employer's confidential material.</p>
+                <p>You keep working exactly as before. No tasks, no deadlines, no meetings: you are selling recordings of work you were doing anyway, not your labor.</p>
             </div>
 
             <section class="detail-section">
@@ -65,10 +70,21 @@
 
             <section class="detail-section">
                 <header class="detail-section-head">
-                    <span class="eyebrow">Sign up</span>
+                    <span class="eyebrow">Privacy &amp; trust</span>
                 </header>
                 <div class="page-prose page-prose--wide">
-                    <p>To sign up, fill out the <a href="https://docs.google.com/forms/d/e/1FAIpQLSd50ZarNRKoIWDmy5xAn8K8FVGM2Jbk1T52er4YLHiP2P28rQ/viewform" target="_blank" rel="noopener">application form</a>.</p>
+                    <p>Only the applications you select are captured; everything else, including pop-ups and notifications, is excluded. You can pause or stop recording at any time from the UI, and deletion requests are honored, including derived data.</p>
+                    <p>Nothing here is take-our-word-for-it: the recorder is <a href="https://github.com/p-doom/crowd-cast">open source</a>, and the exact agreements you'd accept are public before you apply: the <a href="/docs/crowd-cast-data-purchase-agreement.pdf">Data Purchase Agreement</a> and the <a href="/docs/crowd-cast-privacy-consent.pdf">Privacy &amp; Recording Consent</a> (GDPR). p(doom) is publicly funded by <a href="https://www.sprind.org">SPRIND</a>, the German Federal Agency for Breakthrough Innovation.</p>
+                </div>
+            </section>
+
+            <section class="detail-section">
+                <header class="detail-section-head">
+                    <span class="eyebrow">Sign up</span>
+                </header>
+                <div class="apply-hero">
+                    <a class="btn-apply btn-apply--hero" href="https://docs.google.com/forms/d/e/1FAIpQLSd50ZarNRKoIWDmy5xAn8K8FVGM2Jbk1T52er4YLHiP2P28rQ/viewform" target="_blank" rel="noopener">Apply now <span aria-hidden>→</span></a>
+                    <span class="apply-note">We reach out within a few days.</span>
                 </div>
             </section>
 

--- a/public/open_calls/04_crowd_cast.html
+++ b/public/open_calls/04_crowd_cast.html
@@ -51,9 +51,10 @@
             </div>
 
             <div class="page-prose page-prose--wide">
-                <p>We are p(doom), an AGI research lab in Munich. Our goal is models that can perform complex work over weeks and months, and that takes training data nobody has: recordings of real, long-horizon work. <a href="/docs/crowd-cast/">crowd-cast</a> is our open-source desktop recorder, built to capture the largest open dataset of long-horizon computer work. Over <strong>3,000 hours</strong> recorded so far by the team and early participants, watch it grow on the <a href="/crowd_cast_dashboard.html">live dashboard</a>.</p>
-                <p>We pay accepted participants <strong>$300 per month</strong> to record their normal screen work: research, engineering, coding, CAD and hardware workflows. That can be your bachelor or master thesis, a semester project, PhD research, a research job, or a serious side project. We especially want the work current AI <em>can't</em> do yet. It has to be work you have the right to share, your own projects and research, not your employer's confidential material.</p>
-                <p>You keep working exactly as before. No tasks, no deadlines, no meetings: you are selling recordings of work you were doing anyway, not your labor. Install once and forget about it.</p>
+                <p>We are p(doom), an AGI research lab. Our goal is to enable models to perform complex tasks over weeks and months. To elicit such capabilities, we need to train on such data.</p>
+                <p>A few weeks ago we launched <a href="/docs/crowd-cast/">crowd-cast</a>, a privacy-preserving desktop application to capture the largest open long-horizon dataset of digital work. Since then, we have already captured over 3000 hours of work sessions by members of the p(doom) team and early participants (<a href="/crowd_cast_dashboard.html">live dashboard</a>).</p>
+                <p>We are now expanding our data collection efforts to the public and compensate participants <strong>$300 per month</strong> simply for passively recording their work.</p>
+                <p>If you work on open-source projects, and your work involves research, engineering, design, editing, or other long-horizon work, consider participating! This can be a bachelor/master thesis, semester projects, PhD research, a research job at a lab, or even side projects. Simply fill out the form and we will reach out to you.</p>
             </div>
 
             <section class="detail-section">
@@ -73,7 +74,7 @@
                     <span class="eyebrow">Privacy &amp; trust</span>
                 </header>
                 <div class="page-prose page-prose--wide">
-                    <p>Only the applications you select are captured; everything else, including pop-ups and notifications, is excluded. You can pause or stop recording at any time from the UI, and deletion requests are honored, including derived data.</p>
+                    <p>Our privacy-preserving tool lets you choose exactly which applications you want to capture. Private applications, pop-ups and notifications are not captured, and the recording can be started and stopped at any time through the UI. Install once and forget about it! Deletion requests are honored, including derived data.</p>
                     <p>Nothing here is take-our-word-for-it: the recorder is <a href="https://github.com/p-doom/crowd-cast">open source</a>, and the exact agreements you'd accept are public before you apply: the <a href="/docs/crowd-cast-data-purchase-agreement.pdf">Data Purchase Agreement</a> and the <a href="/docs/crowd-cast-privacy-consent.pdf">Privacy &amp; Recording Consent</a> (GDPR). p(doom) is publicly funded by <a href="https://www.sprind.org">SPRIND</a>, the German Federal Agency for Breakthrough Innovation.</p>
                 </div>
             </section>


### PR DESCRIPTION
- **Apply button is now the first thing you see**: hero-sized (`.btn-apply--hero`), directly under the headline, with microcopy (2-min application, $75 trial week, quit anytime); repeated at the bottom
- Copy rewritten: AGI-lab mission framing, 3,000+ hours social proof, work list matches the QC gate (research/engineering/coding/CAD/hardware; removed design/editing), right-to-share caveat
- New **Privacy & trust** section: apps-you-choose model, pause anytime, deletion honored, plus direct links to the public Data Purchase Agreement and Privacy Consent PDFs (the discoverability gap flagged on Reddit), the open-source repo, and SPRIND
- Full-width button on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)