### PR TITLE
Refine crowd-cast apply CTA (size, mobile, "Sign up" label)

### DIFF
--- a/public/marketing.css
+++ b/public/marketing.css
@@ -776,11 +776,12 @@ h1.hero-manifesto.display {
 }
 .btn-apply:hover { background: var(--ember); border-color: var(--ember); color: var(--paper); }
 
-/* Hero-sized apply button: the first thing visitors should see. */
+/* Hero apply button: prominent but restrained. It reads as the primary
+   action because it's the only filled dark button up top, not because it's huge. */
 .btn-apply--hero {
-  font-size: 18px;
+  font-size: 14px;
   letter-spacing: .12em;
-  padding: 22px 48px;
+  padding: 15px 34px;
   margin: 8px 0 4px;
 }
 .apply-hero {
@@ -796,9 +797,10 @@ h1.hero-manifesto.display {
 .apply-note .seg { white-space: nowrap; }
 .apply-note .sep { margin: 0 8px; color: var(--ash-500, #999); }
 @media (max-width: 640px) {
-  .btn-apply--hero { display: flex; justify-content: center; width: 100%; }
-  /* Stack the microcopy as tidy centered lines instead of mid-phrase wraps. */
-  .apply-hero { text-align: center; }
+  /* Size to content and center it, rather than spanning the whole screen. */
+  .btn-apply--hero { display: inline-flex; width: auto; }
+  /* Keep the button and microcopy on the same left edge as the headline and body. */
+  .apply-hero { text-align: left; }
   .apply-note .sep { display: none; }
   .apply-note .seg { display: block; line-height: 1.9; }
 }

--- a/public/open_calls/04_crowd_cast.html
+++ b/public/open_calls/04_crowd_cast.html
@@ -15,7 +15,7 @@
             <span class="announce-msg">
                 We pay <strong class="announce-figure">$300/month</strong> to record your screen for AI research.
             </span>
-            <span class="announce-cta">Apply<span aria-hidden>→</span></span>
+            <span class="announce-cta">Sign up<span aria-hidden>→</span></span>
         </a>
         <button class="announce-close" type="button" aria-label="Dismiss announcement">×</button>
     </aside>
@@ -46,7 +46,7 @@
             <p class="detail-tag"><span class="dot">●</span>live · remote · $300 per month</p>
 
             <div class="apply-hero">
-                <a class="btn-apply btn-apply--hero" href="https://docs.google.com/forms/d/e/1FAIpQLSd50ZarNRKoIWDmy5xAn8K8FVGM2Jbk1T52er4YLHiP2P28rQ/viewform" target="_blank" rel="noopener">Apply now <span aria-hidden>→</span></a>
+                <a class="btn-apply btn-apply--hero" href="https://docs.google.com/forms/d/e/1FAIpQLSd50ZarNRKoIWDmy5xAn8K8FVGM2Jbk1T52er4YLHiP2P28rQ/viewform" target="_blank" rel="noopener">Sign up <span aria-hidden>→</span></a>
             </div>
 
             <div class="page-prose page-prose--wide">
@@ -80,10 +80,10 @@
 
             <section class="detail-section">
                 <header class="detail-section-head">
-                    <span class="eyebrow">Sign up</span>
+                    <span class="eyebrow">Interested?</span>
                 </header>
                 <div class="apply-hero">
-                    <a class="btn-apply btn-apply--hero" href="https://docs.google.com/forms/d/e/1FAIpQLSd50ZarNRKoIWDmy5xAn8K8FVGM2Jbk1T52er4YLHiP2P28rQ/viewform" target="_blank" rel="noopener">Apply now <span aria-hidden>→</span></a>
+                    <a class="btn-apply btn-apply--hero" href="https://docs.google.com/forms/d/e/1FAIpQLSd50ZarNRKoIWDmy5xAn8K8FVGM2Jbk1T52er4YLHiP2P28rQ/viewform" target="_blank" rel="noopener">Sign up <span aria-hidden>→</span></a>
                     <span class="apply-note">We reach out within a few days.</span>
                 </div>
             </section>


### PR DESCRIPTION
Polishes the apply call-to-action on the crowd-cast participate page (`/open_calls/04_crowd_cast.html`) after feedback that the button looked oversized and unserious, and stretched edge-to-edge on mobile.

## Changes
- **Restrained hero button.** Shrunk from 18px / 22×48 padding to 14px / 15×34. It stays unmissable because it's the only filled dark button at the top of a light page, not because it's huge.
- **Mobile width fix.** Button now sizes to its content instead of spanning the full screen width.
- **Left alignment.** Button and microcopy hang on the same left edge as the headline and body on mobile (was centered), matching the page's editorial column.
- **Label.** "Apply now" → **"Sign up"** on both hero buttons and the top announce chip.
- **Closing eyebrow.** "Sign up" → **"Interested?"** so the section title no longer duplicates the button right below it.

Also carries three earlier commits on this branch (mobile microcopy wrapping fix, hero microcopy removal, privacy-paragraph tweak).

## Test
Checked at desktop and <640px widths locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)